### PR TITLE
Couple more packages

### DIFF
--- a/indicator-messages-git/.SRCINFO
+++ b/indicator-messages-git/.SRCINFO
@@ -1,0 +1,27 @@
+pkgbase = indicator-messages-git
+	pkgdesc = Notifications indicator
+	pkgver = r1979.1d60a2d
+	pkgrel = 1
+	url = https://github.com/ubports/indicator-messages
+	arch = x86_64
+	arch = i686
+	arch = armv7h
+	arch = aarch64
+	license = GPL3
+	makedepends = git
+	makedepends = gobject-introspection
+	makedepends = intltool
+	makedepends = gtk-doc
+	makedepends = dbus-test-runner
+	depends = accountsservice-ubuntu
+	provides = indicator-messages
+	conflicts = indicator-messages
+	source = git+https://github.com/ubports/indicator-messages.git
+	source = 0001-Replace-gnome-common-in-autogen.sh.patch
+	source = 0002-Fix-build-with-new-glib-versions.patch
+	sha256sums = SKIP
+	sha256sums = 023ee2b2f057588f2dc8cc1827c3dfddc965d87e40b5292fd5882f1e16878aa6
+	sha256sums = 1bd5780d16c228b008cb4170f4971609189223d09e65929541a9101969d8e975
+
+pkgname = indicator-messages-git
+

--- a/indicator-messages-git/0001-Replace-gnome-common-in-autogen.sh.patch
+++ b/indicator-messages-git/0001-Replace-gnome-common-in-autogen.sh.patch
@@ -1,0 +1,65 @@
+From b72568c0290afe5d479c0ac7619234c77e18cad9 Mon Sep 17 00:00:00 2001
+From: Luca Weiss <luca@z3ntu.xyz>
+Date: Sat, 25 Jan 2020 12:26:31 +0100
+Subject: [PATCH 1/2] Replace gnome-common in autogen.sh
+
+See https://wiki.gnome.org/Projects/GnomeCommon/Migration
+---
+ autogen.sh | 42 ++++++++++++++++++++++++++++++++++++------
+ 1 file changed, 36 insertions(+), 6 deletions(-)
+
+diff --git a/autogen.sh b/autogen.sh
+index 1abf3a7..1a5af06 100755
+--- a/autogen.sh
++++ b/autogen.sh
+@@ -1,11 +1,41 @@
+ #!/bin/sh
++# Run this to generate all the initial makefiles, etc.
++test -n "$srcdir" || srcdir=$(dirname "$0")
++test -n "$srcdir" || srcdir=.
+ 
+-PKG_NAME="indicator-messages"
++olddir=$(pwd)
+ 
+-which gnome-autogen.sh || {
+-	echo "You need gnome-common from GNOME SVN"
+-	exit 1
++cd $srcdir
++
++(test -f configure.ac) || {
++        echo "*** ERROR: Directory '$srcdir' does not look like the top-level project directory ***"
++        exit 1
+ }
+ 
+-USE_GNOME2_MACROS=1 \
+-. gnome-autogen.sh
++# shellcheck disable=SC2016
++PKG_NAME=$(autoconf --trace 'AC_INIT:$1' configure.ac)
++
++if [ "$#" = 0 -a "x$NOCONFIGURE" = "x" ]; then
++        echo "*** WARNING: I am going to run 'configure' with no arguments." >&2
++        echo "*** If you wish to pass any to it, please specify them on the" >&2
++        echo "*** '$0' command line." >&2
++        echo "" >&2
++fi
++
++aclocal --install || exit 1
++intltoolize --force --copy --automake || exit 1
++gtkdocize --copy || exit 1
++autoreconf --verbose --force --install || exit 1
++
++cd "$olddir"
++if [ "$NOCONFIGURE" = "" ]; then
++        $srcdir/configure "$@" || exit 1
++
++        if [ "$1" = "--help" ]; then
++                exit 0
++        else
++                echo "Now type 'make' to compile $PKG_NAME" || exit 1
++        fi
++else
++        echo "Skipping configure process."
++fi
+-- 
+2.25.0
+

--- a/indicator-messages-git/0002-Fix-build-with-new-glib-versions.patch
+++ b/indicator-messages-git/0002-Fix-build-with-new-glib-versions.patch
@@ -1,0 +1,138 @@
+From cf14aa88b4823858d8d3070a0c50664b0efd8ca0 Mon Sep 17 00:00:00 2001
+From: Luca Weiss <luca@z3ntu.xyz>
+Date: Sat, 25 Jan 2020 12:30:32 +0100
+Subject: [PATCH 2/2] Fix build with new glib versions
+
+Replace use of deprecated g_type_class_add_private.
+Replace use of deprecated G_TYPE_INSTANCE_GET_PRIVATE.
+
+Bump the minimal required version of glib to 2.38.0, the version
+where G_PRIVATE_ADD was added.
+---
+ configure.ac                      |  2 +-
+ src/im-accounts-service.c         |  8 +++-----
+ src/indicator-desktop-shortcuts.c | 14 ++++++--------
+ 3 files changed, 10 insertions(+), 14 deletions(-)
+
+diff --git a/configure.ac b/configure.ac
+index 7986cf6..080c46e 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -39,7 +39,7 @@ AC_PROG_CXX
+ ###########################
+ 
+ GIO_UNIX_REQUIRED_VERSION=2.33.10
+-GLIB_REQUIRED_VERSION=2.35.4
++GLIB_REQUIRED_VERSION=2.38.0
+ INTROSPECTION_REQUIRED_VERSION=1.32.0
+ 
+ PKG_CHECK_MODULES(APPLET, gio-unix-2.0 >= $GIO_UNIX_REQUIRED_VERSION
+diff --git a/src/im-accounts-service.c b/src/im-accounts-service.c
+index b7ab15d..ee55817 100644
+--- a/src/im-accounts-service.c
++++ b/src/im-accounts-service.c
+@@ -34,7 +34,7 @@ struct _ImAccountsServicePrivate {
+ };
+ 
+ #define IM_ACCOUNTS_SERVICE_GET_PRIVATE(o) \
+-(G_TYPE_INSTANCE_GET_PRIVATE ((o), IM_ACCOUNTS_SERVICE_TYPE, ImAccountsServicePrivate))
++(im_accounts_service_get_instance_private (o))
+ 
+ static void im_accounts_service_class_init (ImAccountsServiceClass *klass);
+ static void im_accounts_service_init       (ImAccountsService *self);
+@@ -44,15 +44,13 @@ static void user_changed (ActUserManager * manager, ActUser * user, gpointer use
+ static void on_user_manager_loaded (ActUserManager * manager, GParamSpec * pspect, gpointer user_data);
+ static void security_privacy_ready (GObject * obj, GAsyncResult * res, gpointer user_data);
+ 
+-G_DEFINE_TYPE (ImAccountsService, im_accounts_service, G_TYPE_OBJECT);
++G_DEFINE_TYPE_WITH_PRIVATE (ImAccountsService, im_accounts_service, G_TYPE_OBJECT);
+ 
+ static void
+ im_accounts_service_class_init (ImAccountsServiceClass *klass)
+ {
+ 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+ 
+-	g_type_class_add_private (klass, sizeof (ImAccountsServicePrivate));
+-
+ 	object_class->dispose = im_accounts_service_dispose;
+ 	object_class->finalize = im_accounts_service_finalize;
+ }
+@@ -78,7 +76,7 @@ im_accounts_service_init (ImAccountsService *self)
+ static void
+ im_accounts_service_dispose (GObject *object)
+ {
+-	ImAccountsServicePrivate * priv = IM_ACCOUNTS_SERVICE_GET_PRIVATE(object);
++	ImAccountsServicePrivate * priv = IM_ACCOUNTS_SERVICE_GET_PRIVATE(IM_ACCOUNTS_SERVICE (object));
+ 
+ 	if (priv->cancel != NULL) {
+ 		g_cancellable_cancel(priv->cancel);
+diff --git a/src/indicator-desktop-shortcuts.c b/src/indicator-desktop-shortcuts.c
+index 7b43630..bf5198a 100644
+--- a/src/indicator-desktop-shortcuts.c
++++ b/src/indicator-desktop-shortcuts.c
+@@ -61,7 +61,7 @@ enum {
+ };
+ 
+ #define INDICATOR_DESKTOP_SHORTCUTS_GET_PRIVATE(o) \
+-		(G_TYPE_INSTANCE_GET_PRIVATE ((o), INDICATOR_TYPE_DESKTOP_SHORTCUTS, IndicatorDesktopShortcutsPrivate))
++		(indicator_desktop_shortcuts_get_instance_private (o))
+ 
+ static void indicator_desktop_shortcuts_class_init (IndicatorDesktopShortcutsClass *klass);
+ static void indicator_desktop_shortcuts_init       (IndicatorDesktopShortcuts *self);
+@@ -72,7 +72,7 @@ static void get_property (GObject * object, guint prop_id, GValue * value, GPara
+ static void parse_keyfile (IndicatorDesktopShortcuts * ids);
+ static gboolean should_show (GKeyFile * keyfile, const gchar * group, const gchar * identity, gboolean should_have_target);
+ 
+-G_DEFINE_TYPE (IndicatorDesktopShortcuts, indicator_desktop_shortcuts, G_TYPE_OBJECT);
++G_DEFINE_TYPE_WITH_PRIVATE (IndicatorDesktopShortcuts, indicator_desktop_shortcuts, G_TYPE_OBJECT);
+ 
+ /* Build up the class */
+ static void
+@@ -80,8 +80,6 @@ indicator_desktop_shortcuts_class_init (IndicatorDesktopShortcutsClass *klass)
+ {
+ 	GObjectClass *object_class = G_OBJECT_CLASS (klass);
+ 
+-	g_type_class_add_private (klass, sizeof (IndicatorDesktopShortcutsPrivate));
+-
+ 	object_class->dispose = indicator_desktop_shortcuts_dispose;
+ 	object_class->finalize = indicator_desktop_shortcuts_finalize;
+ 
+@@ -124,7 +122,7 @@ indicator_desktop_shortcuts_init (IndicatorDesktopShortcuts *self)
+ static void
+ indicator_desktop_shortcuts_dispose (GObject *object)
+ {
+-	IndicatorDesktopShortcutsPrivate * priv = INDICATOR_DESKTOP_SHORTCUTS_GET_PRIVATE(object);
++	IndicatorDesktopShortcutsPrivate * priv = INDICATOR_DESKTOP_SHORTCUTS_GET_PRIVATE(INDICATOR_DESKTOP_SHORTCUTS (object));
+ 
+ 	if (priv->keyfile) {
+ 		g_key_file_free(priv->keyfile);
+@@ -139,7 +137,7 @@ indicator_desktop_shortcuts_dispose (GObject *object)
+ static void
+ indicator_desktop_shortcuts_finalize (GObject *object)
+ {
+-	IndicatorDesktopShortcutsPrivate * priv = INDICATOR_DESKTOP_SHORTCUTS_GET_PRIVATE(object);
++	IndicatorDesktopShortcutsPrivate * priv = INDICATOR_DESKTOP_SHORTCUTS_GET_PRIVATE(INDICATOR_DESKTOP_SHORTCUTS (object));
+ 
+ 	if (priv->identity != NULL) {
+ 		g_free(priv->identity);
+@@ -170,7 +168,7 @@ static void
+ set_property (GObject * object, guint prop_id, const GValue * value, GParamSpec * pspec)
+ {
+ 	g_return_if_fail(INDICATOR_IS_DESKTOP_SHORTCUTS(object));
+-	IndicatorDesktopShortcutsPrivate * priv = INDICATOR_DESKTOP_SHORTCUTS_GET_PRIVATE(object);
++	IndicatorDesktopShortcutsPrivate * priv = INDICATOR_DESKTOP_SHORTCUTS_GET_PRIVATE(INDICATOR_DESKTOP_SHORTCUTS (object));
+ 
+ 	switch(prop_id) {
+ 	case PROP_DESKTOP_FILE: {
+@@ -233,7 +231,7 @@ static void
+ get_property (GObject * object, guint prop_id, GValue * value, GParamSpec * pspec)
+ {
+ 	g_return_if_fail(INDICATOR_IS_DESKTOP_SHORTCUTS(object));
+-	IndicatorDesktopShortcutsPrivate * priv = INDICATOR_DESKTOP_SHORTCUTS_GET_PRIVATE(object);
++	IndicatorDesktopShortcutsPrivate * priv = INDICATOR_DESKTOP_SHORTCUTS_GET_PRIVATE(INDICATOR_DESKTOP_SHORTCUTS (object));
+ 
+ 	switch(prop_id) {
+ 	case PROP_IDENTITY:
+-- 
+2.25.0
+

--- a/indicator-messages-git/PKGBUILD
+++ b/indicator-messages-git/PKGBUILD
@@ -1,5 +1,3 @@
-# Maintainer: Ivan Semkin (ivan at semkin dot ru)
-
 pkgname=indicator-messages-git
 _pkgname=indicator-messages
 pkgver=r1979.1d60a2d

--- a/indicator-messages-git/PKGBUILD
+++ b/indicator-messages-git/PKGBUILD
@@ -1,0 +1,50 @@
+# Maintainer: Ivan Semkin (ivan at semkin dot ru)
+
+pkgname=indicator-messages-git
+_pkgname=indicator-messages
+pkgver=r1979.1d60a2d
+pkgrel=1
+pkgdesc='Notifications indicator'
+url='https://github.com/ubports/indicator-messages'
+arch=(x86_64 i686 armv7h aarch64)
+license=(GPL3)
+conflicts=(indicator-messages)
+provides=(indicator-messages)
+depends=(accountsservice-ubuntu)
+makedepends=(git gobject-introspection intltool gtk-doc dbus-test-runner)
+source=('git+https://github.com/ubports/indicator-messages.git'
+        '0001-Replace-gnome-common-in-autogen.sh.patch'
+        '0002-Fix-build-with-new-glib-versions.patch')
+sha256sums=('SKIP'
+            '023ee2b2f057588f2dc8cc1827c3dfddc965d87e40b5292fd5882f1e16878aa6'
+            '1bd5780d16c228b008cb4170f4971609189223d09e65929541a9101969d8e975')
+
+pkgver() {
+  cd ${_pkgname}
+  echo "r$(git rev-list --count HEAD).$(git describe --always)"
+}
+
+prepare() {
+  cd ${_pkgname}
+  patch -Np1 -i ../0001-Replace-gnome-common-in-autogen.sh.patch
+  patch -Np1 -i ../0002-Fix-build-with-new-glib-versions.patch
+}
+
+build() {
+  cd ${_pkgname}
+  ./autogen.sh
+  ./configure --prefix=/usr --disable-packagekit
+  make
+}
+
+check() {
+  cd ${_pkgname}
+  make check
+}
+
+package() {
+  cd ${_pkgname}
+  make DESTDIR="${pkgdir}/" PYTHON_INSTALL_FLAGS="--root=${pkgdir}/" install
+}
+
+# vim:set ts=2 sw=2 et:

--- a/ubuntu-download-manager-git/PKGBUILD
+++ b/ubuntu-download-manager-git/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=ubuntu-download-manager-git
 _pkgname=ubuntu-download-manager
-pkgver=r2545.695e5dc8
+pkgver=r2545.f0dea590
 pkgrel=1
 pkgdesc='Provides a service for downloading files while an application is suspended'
 url='https://github.com/ubports/ubuntu-download-manager'
@@ -12,7 +12,7 @@ conflicts=(ubuntu-download-manager)
 provides=(ubuntu-download-manager)
 depends=(boost dbus-test-runner gmock qt5-base qt5-declarative libnih google-glog)
 makedepends=(git doxygen cmake cmake-extras-git gcovr lcov)
-source=('git+https://github.com/ubports/ubuntu-download-manager.git'
+source=('git+https://github.com/ubports/ubuntu-download-manager.git#branch=xenial'
         'QtArg.patch')
 sha256sums=('SKIP'
             '8182121308e04f60e29dfc1e3c8e221413b5a905ea1302e75acbe95a6bb7f866')
@@ -21,8 +21,6 @@ BUILDENV+=('!check') # Some tests are broken
 
 prepare() {
   cd ${_pkgname}
-  git checkout bionic
-  
   patch -Np1 -i "${srcdir}/QtArg.patch"
 }
 

--- a/ubuntu-push/.SRCINFO
+++ b/ubuntu-push/.SRCINFO
@@ -1,0 +1,28 @@
+pkgbase = ubuntu-push-git
+	pkgdesc = Protocol, client, and development code for Ubuntu Touch push notifications
+	pkgver = r2434.c4bb268
+	pkgrel = 1
+	url = https://github.com/ubports/ubuntu-push
+	arch = x86_64
+	license = GPL
+	makedepends = git
+	makedepends = go
+	makedepends = click
+	makedepends = url-dispatcher
+	makedepends = ubuntu-app-launch
+	makedepends = indicator-messages
+	provides = ubuntu-push
+	conflicts = ubuntu-push
+	source = git+https://github.com/ubports/ubuntu-push
+	source = 0001-Remove-v0-suffix-from-go-xdg-imports.patch
+	source = 0002-Remove-v1-suffix-from-go-dbus-imports.patch
+	source = 0003-Initial-conversion-to-Go-modules.patch
+	source = 0004-cual-link-against-ual-3.patch
+	sha512sums = SKIP
+	sha512sums = 89c9e7b705b95225d2b82395100eae0078fa15c5acc4e84f536a76f08b2a0c8f9f0df5ce3fce2ae45a77b13ab834a12540f5f22f39614cf36cd130cf01c8f7d6
+	sha512sums = 728af821c5fba83d0b3c47d29d774a1fda947dc55e725fda6989f91130878dc62cdc5aea99332f13865d18719536b8f70add5af79535bed6252eb4336d1fd0ff
+	sha512sums = 2ac56d0c75e020463d841a017db31ea4c9dc26177e55d6a408a44545cbda376c5277ae91588b5f4fb549b4516303398496489d9d6260bb197e44bb2fc7f71309
+	sha512sums = c3472012d999fce9f9fb1d062ddf77cd401ca0197618e5ae4633f4cff88f699f8aca373ccd89740adc16b8a9aeee26a96a75dff0ce0bdd2f99058fb993b0b37f
+
+pkgname = ubuntu-push-git
+

--- a/ubuntu-push/0001-Remove-v0-suffix-from-go-xdg-imports.patch
+++ b/ubuntu-push/0001-Remove-v0-suffix-from-go-xdg-imports.patch
@@ -1,0 +1,113 @@
+From 7b4a5c676361d7f1e61822dea77b2e4507bfcf73 Mon Sep 17 00:00:00 2001
+From: Luca Weiss <luca@z3ntu.xyz>
+Date: Sat, 25 Jan 2020 11:37:48 +0100
+Subject: [PATCH 1/4] Remove v0 suffix from go-xdg imports
+
+See https://github.com/golang/go/wiki/Modules#semantic-import-versioning:
+
+> If the module is version v0 or v1, do not include the major version in
+  either the module path or the import path.
+---
+ bus/accounts/accounts.go                     | 2 +-
+ click/click.go                               | 2 +-
+ launch_helper/helper_finder/helper_finder.go | 2 +-
+ launch_helper/kindpool.go                    | 2 +-
+ launch_helper/kindpool_test.go               | 2 +-
+ sounds/sounds.go                             | 2 +-
+ ubuntu-push-client.go                        | 2 +-
+ 7 files changed, 7 insertions(+), 7 deletions(-)
+
+diff --git a/bus/accounts/accounts.go b/bus/accounts/accounts.go
+index 3be212a..4812ccf 100644
+--- a/bus/accounts/accounts.go
++++ b/bus/accounts/accounts.go
+@@ -25,7 +25,7 @@ import (
+ 	"sync"
+ 
+ 	"launchpad.net/go-dbus/v1"
+-	"launchpad.net/go-xdg/v0"
++	"launchpad.net/go-xdg"
+ 
+ 	"github.com/ubports/ubuntu-push/bus"
+ 	"github.com/ubports/ubuntu-push/logger"
+diff --git a/click/click.go b/click/click.go
+index 337b6f4..cff1dae 100644
+--- a/click/click.go
++++ b/click/click.go
+@@ -27,7 +27,7 @@ import (
+ 	"strings"
+ 	"sync"
+ 
+-	"launchpad.net/go-xdg/v0"
++	"launchpad.net/go-xdg"
+ 
+ 	"github.com/ubports/ubuntu-push/click/cappinfo"
+ 	"github.com/ubports/ubuntu-push/click/cclick"
+diff --git a/launch_helper/helper_finder/helper_finder.go b/launch_helper/helper_finder/helper_finder.go
+index dcd96e8..725a118 100644
+--- a/launch_helper/helper_finder/helper_finder.go
++++ b/launch_helper/helper_finder/helper_finder.go
+@@ -8,7 +8,7 @@ import (
+ 	"sync"
+ 	"time"
+ 
+-	"launchpad.net/go-xdg/v0"
++	"launchpad.net/go-xdg"
+ 
+ 	"github.com/ubports/ubuntu-push/click"
+ 	"github.com/ubports/ubuntu-push/logger"
+diff --git a/launch_helper/kindpool.go b/launch_helper/kindpool.go
+index 3b598be..cc12084 100644
+--- a/launch_helper/kindpool.go
++++ b/launch_helper/kindpool.go
+@@ -26,7 +26,7 @@ import (
+ 	"sync"
+ 	"time"
+ 
+-	xdg "launchpad.net/go-xdg/v0"
++	xdg "launchpad.net/go-xdg"
+ 
+ 	"github.com/ubports/ubuntu-push/click"
+ 	"github.com/ubports/ubuntu-push/launch_helper/cual"
+diff --git a/launch_helper/kindpool_test.go b/launch_helper/kindpool_test.go
+index f3358cf..26f4f5f 100644
+--- a/launch_helper/kindpool_test.go
++++ b/launch_helper/kindpool_test.go
+@@ -24,7 +24,7 @@ import (
+ 	"path/filepath"
+ 	"time"
+ 
+-	xdg "launchpad.net/go-xdg/v0"
++	xdg "launchpad.net/go-xdg"
+ 	. "launchpad.net/gocheck"
+ 
+ 	"github.com/ubports/ubuntu-push/click"
+diff --git a/sounds/sounds.go b/sounds/sounds.go
+index 29a3b7e..470f776 100644
+--- a/sounds/sounds.go
++++ b/sounds/sounds.go
+@@ -23,7 +23,7 @@ import (
+ 	"path/filepath"
+ 	"strings"
+ 
+-	"launchpad.net/go-xdg/v0"
++	"launchpad.net/go-xdg"
+ 
+ 	"github.com/ubports/ubuntu-push/bus/accounts"
+ 	"github.com/ubports/ubuntu-push/click"
+diff --git a/ubuntu-push-client.go b/ubuntu-push-client.go
+index d82394e..50b1576 100644
+--- a/ubuntu-push-client.go
++++ b/ubuntu-push-client.go
+@@ -23,7 +23,7 @@ import (
+ 	"runtime"
+ 	"syscall"
+ 
+-	"launchpad.net/go-xdg/v0"
++	"launchpad.net/go-xdg"
+ 
+ 	"github.com/ubports/ubuntu-push/client"
+ )
+-- 
+2.25.0
+

--- a/ubuntu-push/0002-Remove-v1-suffix-from-go-dbus-imports.patch
+++ b/ubuntu-push/0002-Remove-v1-suffix-from-go-dbus-imports.patch
@@ -1,0 +1,263 @@
+From 4ad32991099257c403648bf892ab19ab9dae88d0 Mon Sep 17 00:00:00 2001
+From: Luca Weiss <luca@z3ntu.xyz>
+Date: Sat, 25 Jan 2020 12:11:46 +0100
+Subject: [PATCH 2/4] Remove v1 suffix from go-dbus imports
+
+---
+ bus/accounts/accounts.go                  | 2 +-
+ bus/accounts/accounts_test.go             | 2 +-
+ bus/bus.go                                | 2 +-
+ bus/bus_test.go                           | 2 +-
+ bus/connectivity/connectivity_test.go     | 2 +-
+ bus/emblemcounter/emblemcounter.go        | 2 +-
+ bus/emblemcounter/emblemcounter_test.go   | 2 +-
+ bus/endpoint.go                           | 2 +-
+ bus/networkmanager/networkmanager.go      | 2 +-
+ bus/networkmanager/networkmanager_test.go | 2 +-
+ bus/notifications/raw.go                  | 2 +-
+ bus/notifications/raw_test.go             | 2 +-
+ bus/testing/testing_endpoint.go           | 2 +-
+ bus/testing/testing_endpoint_test.go      | 2 +-
+ bus/urfkill/urfkill.go                    | 2 +-
+ bus/urfkill/urfkill_test.go               | 2 +-
+ client/client_test.go                     | 2 +-
+ client/service/postal_test.go             | 2 +-
+ 18 files changed, 18 insertions(+), 18 deletions(-)
+
+diff --git a/bus/accounts/accounts.go b/bus/accounts/accounts.go
+index 4812ccf..b765138 100644
+--- a/bus/accounts/accounts.go
++++ b/bus/accounts/accounts.go
+@@ -24,7 +24,7 @@ import (
+ 	"strings"
+ 	"sync"
+ 
+-	"launchpad.net/go-dbus/v1"
++	"launchpad.net/go-dbus"
+ 	"launchpad.net/go-xdg"
+ 
+ 	"github.com/ubports/ubuntu-push/bus"
+diff --git a/bus/accounts/accounts_test.go b/bus/accounts/accounts_test.go
+index 3675251..c63082f 100644
+--- a/bus/accounts/accounts_test.go
++++ b/bus/accounts/accounts_test.go
+@@ -20,7 +20,7 @@ import (
+ 	"errors"
+ 	"testing"
+ 
+-	"launchpad.net/go-dbus/v1"
++	"launchpad.net/go-dbus"
+ 	. "launchpad.net/gocheck"
+ 
+ 	testibus "github.com/ubports/ubuntu-push/bus/testing"
+diff --git a/bus/bus.go b/bus/bus.go
+index a4aab7b..a584fd8 100644
+--- a/bus/bus.go
++++ b/bus/bus.go
+@@ -20,7 +20,7 @@ package bus
+ // Here we define the Bus itself
+ 
+ import (
+-	"launchpad.net/go-dbus/v1"
++	"launchpad.net/go-dbus"
+ 	"github.com/ubports/ubuntu-push/logger"
+ )
+ 
+diff --git a/bus/bus_test.go b/bus/bus_test.go
+index 1cea472..10be830 100644
+--- a/bus/bus_test.go
++++ b/bus/bus_test.go
+@@ -18,7 +18,7 @@ package bus
+ 
+ import (
+ 	"fmt"
+-	"launchpad.net/go-dbus/v1"
++	"launchpad.net/go-dbus"
+ 	. "launchpad.net/gocheck"
+ 	helpers "github.com/ubports/ubuntu-push/testing"
+ 	"testing"
+diff --git a/bus/connectivity/connectivity_test.go b/bus/connectivity/connectivity_test.go
+index 8e0c23e..7d4f7cb 100644
+--- a/bus/connectivity/connectivity_test.go
++++ b/bus/connectivity/connectivity_test.go
+@@ -22,7 +22,7 @@ import (
+ 	"testing"
+ 	"time"
+ 
+-	"launchpad.net/go-dbus/v1"
++	"launchpad.net/go-dbus"
+ 	. "launchpad.net/gocheck"
+ 
+ 	"github.com/ubports/ubuntu-push/bus"
+diff --git a/bus/emblemcounter/emblemcounter.go b/bus/emblemcounter/emblemcounter.go
+index 6ff5b6a..7154abf 100644
+--- a/bus/emblemcounter/emblemcounter.go
++++ b/bus/emblemcounter/emblemcounter.go
+@@ -19,7 +19,7 @@
+ package emblemcounter
+ 
+ import (
+-	"launchpad.net/go-dbus/v1"
++	"launchpad.net/go-dbus"
+ 
+ 	"github.com/ubports/ubuntu-push/bus"
+ 	"github.com/ubports/ubuntu-push/click"
+diff --git a/bus/emblemcounter/emblemcounter_test.go b/bus/emblemcounter/emblemcounter_test.go
+index c8faaa3..f7cdd12 100644
+--- a/bus/emblemcounter/emblemcounter_test.go
++++ b/bus/emblemcounter/emblemcounter_test.go
+@@ -19,7 +19,7 @@ package emblemcounter
+ import (
+ 	"testing"
+ 
+-	"launchpad.net/go-dbus/v1"
++	"launchpad.net/go-dbus"
+ 	. "launchpad.net/gocheck"
+ 
+ 	testibus "github.com/ubports/ubuntu-push/bus/testing"
+diff --git a/bus/endpoint.go b/bus/endpoint.go
+index b735758..c87cbba 100644
+--- a/bus/endpoint.go
++++ b/bus/endpoint.go
+@@ -23,7 +23,7 @@ import (
+ 	"errors"
+ 	"fmt"
+ 
+-	"launchpad.net/go-dbus/v1"
++	"launchpad.net/go-dbus"
+ 
+ 	"github.com/ubports/ubuntu-push/logger"
+ )
+diff --git a/bus/networkmanager/networkmanager.go b/bus/networkmanager/networkmanager.go
+index 28f89ec..7c34010 100644
+--- a/bus/networkmanager/networkmanager.go
++++ b/bus/networkmanager/networkmanager.go
+@@ -21,7 +21,7 @@
+ package networkmanager
+ 
+ import (
+-	"launchpad.net/go-dbus/v1"
++	"launchpad.net/go-dbus"
+ 
+ 	"github.com/ubports/ubuntu-push/bus"
+ 	"github.com/ubports/ubuntu-push/logger"
+diff --git a/bus/networkmanager/networkmanager_test.go b/bus/networkmanager/networkmanager_test.go
+index cf6e69b..9e68f1e 100644
+--- a/bus/networkmanager/networkmanager_test.go
++++ b/bus/networkmanager/networkmanager_test.go
+@@ -19,7 +19,7 @@ package networkmanager
+ import (
+ 	"testing"
+ 
+-	"launchpad.net/go-dbus/v1"
++	"launchpad.net/go-dbus"
+ 	. "launchpad.net/gocheck"
+ 
+ 	testingbus "github.com/ubports/ubuntu-push/bus/testing"
+diff --git a/bus/notifications/raw.go b/bus/notifications/raw.go
+index abb903d..cd61bcf 100644
+--- a/bus/notifications/raw.go
++++ b/bus/notifications/raw.go
+@@ -25,7 +25,7 @@ import (
+ 	"encoding/json"
+ 	"errors"
+ 
+-	"launchpad.net/go-dbus/v1"
++	"launchpad.net/go-dbus"
+ 
+ 	"github.com/ubports/ubuntu-push/bus"
+ 	"github.com/ubports/ubuntu-push/click"
+diff --git a/bus/notifications/raw_test.go b/bus/notifications/raw_test.go
+index b57f8da..0e2fc51 100644
+--- a/bus/notifications/raw_test.go
++++ b/bus/notifications/raw_test.go
+@@ -24,7 +24,7 @@ import (
+ 	"testing"
+ 	"time"
+ 
+-	"launchpad.net/go-dbus/v1"
++	"launchpad.net/go-dbus"
+ 	. "launchpad.net/gocheck"
+ 
+ 	"github.com/ubports/ubuntu-push/bus"
+diff --git a/bus/testing/testing_endpoint.go b/bus/testing/testing_endpoint.go
+index f4dc1c6..c09ec98 100644
+--- a/bus/testing/testing_endpoint.go
++++ b/bus/testing/testing_endpoint.go
+@@ -22,7 +22,7 @@ import (
+ 	"errors"
+ 	"fmt"
+ 
+-	"launchpad.net/go-dbus/v1"
++	"launchpad.net/go-dbus"
+ 
+ 	"github.com/ubports/ubuntu-push/bus"
+ 	"github.com/ubports/ubuntu-push/testing/condition"
+diff --git a/bus/testing/testing_endpoint_test.go b/bus/testing/testing_endpoint_test.go
+index 64fcb23..ddb960f 100644
+--- a/bus/testing/testing_endpoint_test.go
++++ b/bus/testing/testing_endpoint_test.go
+@@ -20,7 +20,7 @@ import (
+ 	"testing"
+ 	"time"
+ 
+-	"launchpad.net/go-dbus/v1"
++	"launchpad.net/go-dbus"
+ 	. "launchpad.net/gocheck"
+ 
+ 	"github.com/ubports/ubuntu-push/bus"
+diff --git a/bus/urfkill/urfkill.go b/bus/urfkill/urfkill.go
+index f456f81..569da65 100644
+--- a/bus/urfkill/urfkill.go
++++ b/bus/urfkill/urfkill.go
+@@ -19,7 +19,7 @@
+ package urfkill
+ 
+ import (
+-	"launchpad.net/go-dbus/v1"
++	"launchpad.net/go-dbus"
+ 
+ 	"github.com/ubports/ubuntu-push/bus"
+ 	"github.com/ubports/ubuntu-push/logger"
+diff --git a/bus/urfkill/urfkill_test.go b/bus/urfkill/urfkill_test.go
+index fd30cb5..caf14a7 100644
+--- a/bus/urfkill/urfkill_test.go
++++ b/bus/urfkill/urfkill_test.go
+@@ -19,7 +19,7 @@ package urfkill
+ import (
+ 	"testing"
+ 
+-	"launchpad.net/go-dbus/v1"
++	"launchpad.net/go-dbus"
+ 	. "launchpad.net/gocheck"
+ 
+ 	testingbus "github.com/ubports/ubuntu-push/bus/testing"
+diff --git a/client/client_test.go b/client/client_test.go
+index b19c4b5..820378e 100644
+--- a/client/client_test.go
++++ b/client/client_test.go
+@@ -31,7 +31,7 @@ import (
+ 	"testing"
+ 	"time"
+ 
+-	"launchpad.net/go-dbus/v1"
++	"launchpad.net/go-dbus"
+ 	. "launchpad.net/gocheck"
+ 
+ 	"github.com/ubports/ubuntu-push/bus"
+diff --git a/client/service/postal_test.go b/client/service/postal_test.go
+index 576c5d3..7c0e30d 100644
+--- a/client/service/postal_test.go
++++ b/client/service/postal_test.go
+@@ -27,7 +27,7 @@ import (
+ 	"sync"
+ 	"time"
+ 
+-	"launchpad.net/go-dbus/v1"
++	"launchpad.net/go-dbus"
+ 	. "launchpad.net/gocheck"
+ 
+ 	"github.com/ubports/ubuntu-push/bus"
+-- 
+2.25.0
+

--- a/ubuntu-push/0003-Initial-conversion-to-Go-modules.patch
+++ b/ubuntu-push/0003-Initial-conversion-to-Go-modules.patch
@@ -1,0 +1,50 @@
+From fe732491db7ebf2d0774dd3ddfcfd882447bb886 Mon Sep 17 00:00:00 2001
+From: Luca Weiss <luca@z3ntu.xyz>
+Date: Sat, 25 Jan 2020 12:58:59 +0100
+Subject: [PATCH 3/4] Initial conversion to Go modules
+
+---
+ go.mod | 13 +++++++++++++
+ go.sum | 10 ++++++++++
+ 2 files changed, 23 insertions(+)
+ create mode 100644 go.mod
+ create mode 100644 go.sum
+
+diff --git a/go.mod b/go.mod
+new file mode 100644
+index 0000000..06e38d3
+--- /dev/null
++++ b/go.mod
+@@ -0,0 +1,13 @@
++module github.com/ubports/ubuntu-push
++
++go 1.13
++
++require (
++	github.com/mattn/go-sqlite3 v1.1.1-0.20160927022846-4b0af852c171
++	github.com/pborman/uuid v0.0.0-20160824210600-b984ec7fa9ff
++	launchpad.net/go-dbus v1.0.0-20140208094800-gubd5md7cro3mtxa
++	launchpad.net/go-xdg v0.0.0-20140208094800-000000000010
++	launchpad.net/gocheck v0.0.0-20140225173054-000000000087
++)
++
++replace launchpad.net/go-dbus => github.com/z3ntu/go-dbus v0.0.0-20170220120108-c022b8b2e127
+diff --git a/go.sum b/go.sum
+new file mode 100644
+index 0000000..25b0f45
+--- /dev/null
++++ b/go.sum
+@@ -0,0 +1,10 @@
++github.com/mattn/go-sqlite3 v1.1.1-0.20160927022846-4b0af852c171 h1:bZY9z+CAvIbrKtvxl9Ypy+foX2hxuR5Q+2gziez44CM=
++github.com/mattn/go-sqlite3 v1.1.1-0.20160927022846-4b0af852c171/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
++github.com/pborman/uuid v0.0.0-20160824210600-b984ec7fa9ff h1:pTiDfW+iOjIxjZeCm88gKn/AmR09UGZYZdqif2yPRrM=
++github.com/pborman/uuid v0.0.0-20160824210600-b984ec7fa9ff/go.mod h1:VyrYX9gd7irzKovcSS6BIIEwPRkP2Wm2m9ufcdFSJ34=
++github.com/z3ntu/go-dbus v0.0.0-20170220120108-c022b8b2e127 h1:5uM5CyMgvx0a/ctLJ3ThGt2fghWoX6cPniYNgGeCuJI=
++github.com/z3ntu/go-dbus v0.0.0-20170220120108-c022b8b2e127/go.mod h1:bUTQ2+DQ82yitPELjqsyPbSZGg05fEKaC3eHCGkCiV4=
++launchpad.net/go-xdg v0.0.0-20140208094800-000000000010 h1:67YK4VRwVpu+qdmji/6lNv7y/O6NmH1oaSb/4ETtTck=
++launchpad.net/go-xdg v0.0.0-20140208094800-000000000010/go.mod h1:LvhuQF+z2nM+7tjWchL2jH2sbCGTtyHFhi4s/dDQEOk=
++launchpad.net/gocheck v0.0.0-20140225173054-000000000087 h1:Izowp2XBH6Ya6rv+hqbceQyw/gSGoXfH/UPoTGduL54=
++launchpad.net/gocheck v0.0.0-20140225173054-000000000087/go.mod h1:hj7XX3B/0A+80Vse0e+BUHsHMTEhd0O4cpUHr/e/BUM=
+-- 
+2.25.0
+

--- a/ubuntu-push/0004-cual-link-against-ual-3.patch
+++ b/ubuntu-push/0004-cual-link-against-ual-3.patch
@@ -1,0 +1,25 @@
+From bbfb320a630ac6062cdf53e011bbb00a41ba7551 Mon Sep 17 00:00:00 2001
+From: Luca Weiss <luca@z3ntu.xyz>
+Date: Sat, 25 Jan 2020 13:29:50 +0100
+Subject: [PATCH 4/4] cual: link against ual-3
+
+---
+ launch_helper/cual/cual.go | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/launch_helper/cual/cual.go b/launch_helper/cual/cual.go
+index 76d79a4..5cb8919 100644
+--- a/launch_helper/cual/cual.go
++++ b/launch_helper/cual/cual.go
+@@ -17,7 +17,7 @@
+ package cual
+ 
+ /*
+-#cgo pkg-config: ubuntu-app-launch-2
++#cgo pkg-config: ubuntu-app-launch-3
+ #include <glib.h>
+ 
+ gboolean add_observer (gpointer);
+-- 
+2.25.0
+

--- a/ubuntu-push/PKGBUILD
+++ b/ubuntu-push/PKGBUILD
@@ -1,0 +1,47 @@
+pkgname=ubuntu-push-git
+_pkgname=ubuntu-push
+pkgver=r2434.c4bb268
+pkgrel=1
+pkgdesc="Protocol, client, and development code for Ubuntu Touch push notifications"
+arch=('x86_64')
+url="https://github.com/ubports/ubuntu-push"
+license=('GPL')
+depends=()
+makedepends=('git' 'go' 'click' 'url-dispatcher' 'ubuntu-app-launch' 'indicator-messages')
+provides=('ubuntu-push')
+conflicts=('ubuntu-push')
+source=("git+https://github.com/ubports/ubuntu-push"
+        0001-Remove-v0-suffix-from-go-xdg-imports.patch
+        0002-Remove-v1-suffix-from-go-dbus-imports.patch
+        0003-Initial-conversion-to-Go-modules.patch
+        0004-cual-link-against-ual-3.patch)
+sha512sums=('SKIP'
+            '89c9e7b705b95225d2b82395100eae0078fa15c5acc4e84f536a76f08b2a0c8f9f0df5ce3fce2ae45a77b13ab834a12540f5f22f39614cf36cd130cf01c8f7d6'
+            '728af821c5fba83d0b3c47d29d774a1fda947dc55e725fda6989f91130878dc62cdc5aea99332f13865d18719536b8f70add5af79535bed6252eb4336d1fd0ff'
+            '2ac56d0c75e020463d841a017db31ea4c9dc26177e55d6a408a44545cbda376c5277ae91588b5f4fb549b4516303398496489d9d6260bb197e44bb2fc7f71309'
+            'c3472012d999fce9f9fb1d062ddf77cd401ca0197618e5ae4633f4cff88f699f8aca373ccd89740adc16b8a9aeee26a96a75dff0ce0bdd2f99058fb993b0b37f')
+
+pkgver() {
+  cd ${_pkgname}
+  echo "r$(git rev-list --count HEAD).$(git describe --always)"
+}
+
+prepare(){
+  cd "$_pkgname"
+  patch -Np1 -i ../0001-Remove-v0-suffix-from-go-xdg-imports.patch
+  patch -Np1 -i ../0002-Remove-v1-suffix-from-go-dbus-imports.patch
+  patch -Np1 -i ../0003-Initial-conversion-to-Go-modules.patch
+  patch -Np1 -i ../0004-cual-link-against-ual-3.patch
+}
+
+build(){
+  cd "$_pkgname"
+  go build -o ubuntu-push-client ubuntu-push-client.go
+  go build -o push-server-dev server/dev/server.go
+}
+
+package() {
+  cd "$_pkgname"
+  install -Dm755 ubuntu-push-client "$pkgdir"/usr/bin/ubuntu-push-client
+  install -Dm755 push-server-dev "$pkgdir"/usr/bin/push-server-dev
+}

--- a/ubuntu-ui-toolkit-git/PKGBUILD
+++ b/ubuntu-ui-toolkit-git/PKGBUILD
@@ -13,7 +13,7 @@ provides=(ubuntu-ui-toolkit)
 depends=(qt5-base qt5-quickcontrols lttng-ust libnih qt5-systems qt5-pim qt5-svg qt5-feedback ubuntu-themes qt5-graphicaleffects bluez-libs)
 makedepends=(git)
 checkdepends=()
-source=('git+https://github.com/ubports/ubuntu-ui-toolkit.git#branch=xenial_-_newerqt'
+source=('git+https://github.com/ubports/ubuntu-ui-toolkit.git#branch=xenial'
         'NoWarns.patch'
         'dpkg.patch')
 sha256sums=('SKIP'

--- a/ubuntu-ui-toolkit-git/PKGBUILD
+++ b/ubuntu-ui-toolkit-git/PKGBUILD
@@ -2,7 +2,7 @@
 
 pkgname=ubuntu-ui-toolkit-git
 _pkgname=ubuntu-ui-toolkit
-pkgver=r18022.d19600f2e
+pkgver=r18037.d7a3b681c
 pkgrel=1
 pkgdesc='Qt Components for Ubuntu'
 url='https://github.com/ubports/ubuntu-ui-toolkit'
@@ -13,16 +13,12 @@ provides=(ubuntu-ui-toolkit)
 depends=(qt5-base qt5-quickcontrols lttng-ust libnih qt5-systems qt5-pim qt5-svg qt5-feedback ubuntu-themes qt5-graphicaleffects bluez-libs)
 makedepends=(git)
 checkdepends=()
-source=('git+https://github.com/ubports/ubuntu-ui-toolkit.git#branch=bionic'
+source=('git+https://github.com/ubports/ubuntu-ui-toolkit.git#branch=xenial_-_newerqt'
         'NoWarns.patch'
-        'dpkg.patch'
-        'https://github.com/ubports/ubuntu-ui-toolkit/pull/29.patch'
-        'https://github.com/z3ntu/ubuntu-ui-toolkit/commit/ab542b01f461951dd732d8eb1bdb4bf5df4eea6e.patch')
+        'dpkg.patch')
 sha256sums=('SKIP'
             '3b8a3165161d5c695a7f3f8f3b08a3de11451b8f52276b5b1856730f0aa557c9'
-            '5851aec4b72ddd1556494ab188c6de64ccaa77a1b574a0bd2631916300ac242a'
-            '3933506b2f519ad94c0184b00ff7f40f5716eba79057b79a3dc08e098ae52f99'
-            '807fead1010f0e4a8cbc66c9a4571d3d3211420a7df23b3e348cb836e4010582')
+            '5851aec4b72ddd1556494ab188c6de64ccaa77a1b574a0bd2631916300ac242a')
 
 BUILDENV+=('!check') # It needs a DISPLAY, and I am too tired to set it up now
 
@@ -31,8 +27,6 @@ prepare() {
 
   patch -Np1 -i "${srcdir}/NoWarns.patch"
   patch -Np1 -i "${srcdir}/dpkg.patch"
-  patch -Np1 -i "${srcdir}/29.patch"
-  patch -Np1 -i "${srcdir}/ab542b01f461951dd732d8eb1bdb4bf5df4eea6e.patch"
 }
 
 pkgver() {

--- a/unity-api-git/PKGBUILD
+++ b/unity-api-git/PKGBUILD
@@ -2,8 +2,8 @@
 
 pkgname=unity-api-git
 _pkgname=unity-api
-pkgver=r1102.30dd7b3
-pkgrel=2
+pkgver=r1104.d74beb0
+pkgrel=1
 pkgdesc='API for Unity shell integration'
 url='https://github.com/ubports/unity-api'
 arch=(x86_64 i686 armv7h aarch64)
@@ -12,21 +12,10 @@ conflicts=(unity-api)
 provides=(unity-api)
 depends=(qt5-quickcontrols)
 makedepends=(git cmake cppcheck graphviz libqtdbustest-git cmake-extras-git)
-source=('git+https://github.com/ubports/unity-api.git'
-        'https://patch-diff.githubusercontent.com/raw/ubports/unity-api/pull/18.patch')
-sha256sums=('SKIP'
-            'SKIP')
+source=('git+https://github.com/ubports/unity-api.git#branch=bionic')
+sha256sums=('SKIP')
 
 BUILDENV+=('!check') # Some tests are broken
-
-BUILD_DIR=build
-
-prepare() {
-  cd ${_pkgname}
-  git checkout bionic
-
-  patch -Np1 -i "${srcdir}/18.patch"
-}
 
 pkgver() {
   cd ${_pkgname}
@@ -35,19 +24,19 @@ pkgver() {
 
 build() {
   cd ${_pkgname}
-  mkdir -p ${BUILD_DIR}
-  cd ${BUILD_DIR}
+  mkdir -p build
+  cd build
   cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_INSTALL_LIBDIR="lib/" ..
   make
 }
 
 check() {
-  cd ${_pkgname}/${BUILD_DIR}
+  cd ${_pkgname}/build
   make ARGS+="--output-on-failure" test
 }
 
 package() {
-  cd ${_pkgname}/${BUILD_DIR}
+  cd ${_pkgname}/build
   make DESTDIR="${pkgdir}/" install
 }
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
indicator-messages & ubuntu-push

No idea if the ubuntu-push client actually works on Arch Linux, it definitely crashes without accountsservice-ubuntu running - but at least everything compiles :) Patches are also submitted upstream (except `0004-cual-link-against-ual-3.patch`)